### PR TITLE
Change the order of the configuration check

### DIFF
--- a/src/Traits/Securable.php
+++ b/src/Traits/Securable.php
@@ -17,8 +17,8 @@ trait Securable
 
     public static function bootSecurable(): void
     {
-        if (config('security-notifications.send_notifications')) {
-            static::updated(function (Model $model) {
+        static::updated(function (Model $model) {
+            if (config('security-notifications.send_notifications')) {
                 $changedSecureFields = collect($model->getChanges())->only($model->getSecureFields());
 
                 if ($changedSecureFields->count()) {
@@ -29,8 +29,8 @@ trait Securable
                         $model->refresh()->updated_at,
                     ));
                 }
-            });
-        }
+            }
+        });
     }
 
     public function getSecureFields(): array

--- a/tests/Unit/Events/SecureFieldsUpdatedTest.php
+++ b/tests/Unit/Events/SecureFieldsUpdatedTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Zaengle\LaravelSecurityNotifications\Events\SecureFieldsUpdated;
 use Zaengle\LaravelSecurityNotifications\Tests\Setup\Models\User;
@@ -26,4 +27,23 @@ it('emits event when secure fields are updated', function () {
             && Arr::has($event->fields, 'password')
             && ! Arr::has($event->fields, 'name');
     });
+});
+
+it('an event can be bypassed by setting the config value to false', function () {
+    Event::fake([
+        SecureFieldsUpdated::class,
+    ]);
+
+    $user = User::factory()->create();
+
+    Config::set('security-notifications.send_notifications', false);
+
+    $user->update([
+        'name' => 'New Name', // Not a secure field
+        'email' => 'new@email.com',
+        'username' => 'newusername',
+        'password' => bcrypt('newpassword'),
+    ]);
+
+    Event::assertNotDispatched(SecureFieldsUpdated::class);
 });


### PR DESCRIPTION
This PR changes the order of the `security-notifications.send_notifications` config value and the model updated value so we can choose whether we want to send the notification at runtime.